### PR TITLE
Fix tokenizer constant and header includes

### DIFF
--- a/VectorC/ast_arm64.c
+++ b/VectorC/ast_arm64.c
@@ -10,6 +10,7 @@
 #include "tacky.h"
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 
 // Convert an operand to a string for ARM64 (helper function)
 const char* getARM64Operand(const Operand* op, char* buffer, size_t bufferSize) {

--- a/VectorC/ast_x64.c
+++ b/VectorC/ast_x64.c
@@ -10,6 +10,7 @@
 #include "tacky.h"
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 
 // Convert an operand to a string for x64 (helper function)
 void getX64Operand(const Operand* op, char* buffer, size_t bufferSize) {

--- a/VectorC/lexer.c
+++ b/VectorC/lexer.c
@@ -73,8 +73,8 @@ void initLexer(const char* source) {
 //		{ TOKEN_WHILE, "while" },
 	};
 
-	const size_t kNumTokens = sizeof(s_keywordTokenList) / sizeof(KeyToken);
-	static_assert(kNumTokens < (int32_t)TOKEN_COUNT, "Invalid Token");
+        const size_t kNumTokens = sizeof(s_keywordTokenList) / sizeof(KeyToken);
+        static_assert(sizeof(s_keywordTokenList) / sizeof(KeyToken) < (int32_t)TOKEN_COUNT, "Invalid Token");
 
 	for (int32_t token = 0; token < kNumTokens; ++token) {
 		trieInsert(root, s_keywordTokenList[token].keyword, s_keywordTokenList[token].type);
@@ -344,8 +344,8 @@ const char* getTokenName(TokenType tokenType)
 		[TOKEN_MOD] = "TOKEN_MOD",
 		[TOKEN_BANG] = "TOKEN_BANG",
 		[TOKEN_BANG_EQUAL] = "TOKEN_BANG_EQUAL",
-		[TOKEN_EQUAL] = "TOKEN_EQUAL",
-		[TOKEN_EQUAL_EQUAL] = "TOKEN_EQUAL",
+                [TOKEN_EQUAL] = "TOKEN_EQUAL",
+                [TOKEN_EQUAL_EQUAL] = "TOKEN_EQUAL_EQUAL",
 		[TOKEN_GREATER] = "TOKEN_GREATER",
 		[TOKEN_GREATER_EQUAL] = "TOKEN_GREATER_EQUAL",
 		[TOKEN_LESS] = "TOKEN_LESS",


### PR DESCRIPTION
## Summary
- fix token name table for `TOKEN_EQUAL_EQUAL`
- ensure keyword token count check uses a constant expression
- include `<string.h>` in the x86 and ARM64 code generators to use `strdup`

## Testing
- `cc -Wall -Wextra -std=c11 VectorC/*.c -o vectorc && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68815611bf04832a9da10bee3ecb35b2