### PR TITLE
Add relational operator lowering and comparison codegen for x64/ARM64

### DIFF
--- a/VectorC/ast_arm64.c
+++ b/VectorC/ast_arm64.c
@@ -74,10 +74,19 @@ const char* getARM64InstructionName(ARM64InstructionType type)
 		[ARM64_SUB] = "sub",
 		// Shifts (immediate)
 		[ARM64_LSL] = "lsl",   // lsl wd, wn, #imm
+		[ARM64_LSR] = "lsr",
 		[ARM64_ASR] = "asr",   // asr wd, wn, #imm
 		// Shifts (variable)
 		[ARM64_LSLV] = "lslv",  // lslv wd, wn, wm
+		[ARM64_LSRV] = "lsrv",
 		[ARM64_ASRV] = "asrv",  // asrv wd, wn, wm
+		[ARM64_CMP] = "cmp",
+		[ARM64_CSET_EQ] = "cset",
+		[ARM64_CSET_NE] = "cset",
+		[ARM64_CSET_LT] = "cset",
+		[ARM64_CSET_LE] = "cset",
+		[ARM64_CSET_GT] = "cset",
+		[ARM64_CSET_GE] = "cset",
 
 	};
 
@@ -138,6 +147,27 @@ void generateARM64Function(FILE* outputFile, const Function* func)
 			case ARM64_NEG:
 			case ARM64_MVN:
 				fprintf(outputFile, "    %s %s, %s\n", instructionName, dstBuffer, srcBuffer);
+				break;
+			case ARM64_CMP:
+				fprintf(outputFile, "    cmp %s, %s\n", srcBuffer, src1Buffer);
+				break;
+			case ARM64_CSET_EQ:
+				fprintf(outputFile, "    cset %s, eq\n", dstBuffer);
+				break;
+			case ARM64_CSET_NE:
+				fprintf(outputFile, "    cset %s, ne\n", dstBuffer);
+				break;
+			case ARM64_CSET_LT:
+				fprintf(outputFile, "    cset %s, lt\n", dstBuffer);
+				break;
+			case ARM64_CSET_LE:
+				fprintf(outputFile, "    cset %s, le\n", dstBuffer);
+				break;
+			case ARM64_CSET_GT:
+				fprintf(outputFile, "    cset %s, gt\n", dstBuffer);
+				break;
+			case ARM64_CSET_GE:
+				fprintf(outputFile, "    cset %s, ge\n", dstBuffer);
 				break;
 			case ARM64_MOV:
 				// Example: mov x0, #100 => "mov x0, #100"
@@ -358,7 +388,32 @@ void translateTackyToARM64(const TackyProgram* tackyProgram, Program* asmProgram
 								.dst  = VAR(instr->binary.dst.varName),
 							});
 							break;
-						}					}
+						}
+						case TACKY_EQ:
+						case TACKY_NE:
+						case TACKY_LT:
+						case TACKY_LE:
+						case TACKY_GT:
+						case TACKY_GE: {
+							emitARM64(&arm64Instructions, (ARM64Instruction){
+								.type = ARM64_CMP,
+								.src = src0,
+								.src1 = src1,
+							});
+							ARM64InstructionType csetType =
+								(instr->binary.op == TACKY_EQ) ? ARM64_CSET_EQ :
+								(instr->binary.op == TACKY_NE) ? ARM64_CSET_NE :
+								(instr->binary.op == TACKY_LT) ? ARM64_CSET_LT :
+								(instr->binary.op == TACKY_LE) ? ARM64_CSET_LE :
+								(instr->binary.op == TACKY_GT) ? ARM64_CSET_GT :
+								/* TACKY_GE */                 ARM64_CSET_GE;
+							emitARM64(&arm64Instructions, (ARM64Instruction){
+								.type = csetType,
+								.dst = VAR(instr->binary.dst.varName),
+							});
+							break;
+						}
+					}
 					break;
 				}
 				case TACKY_INSTR_RETURN: {
@@ -499,6 +554,33 @@ void fixupIllegalInstructionsARM64(Program* asmProgram, Program* finalAsmProgram
 					}
 					break;
 
+				case ARM64_CMP: {
+					Operand lhs = instr->src;
+					Operand rhs = instr->src1;
+					if (instr->src.type == OPERAND_STACK_SLOT || instr->src.type == OPERAND_IMM) {
+						arrput(fixedInstructions, ((ARM64Instruction){ .type = (instr->src.type==OPERAND_STACK_SLOT)?ARM64_LDR:ARM64_MOV, .src = instr->src, .dst = REG("w11") }));
+						lhs = REG("w11");
+					}
+					if (instr->src1.type == OPERAND_STACK_SLOT || instr->src1.type == OPERAND_IMM) {
+						arrput(fixedInstructions, ((ARM64Instruction){ .type = (instr->src1.type==OPERAND_STACK_SLOT)?ARM64_LDR:ARM64_MOV, .src = instr->src1, .dst = REG("w12") }));
+						rhs = REG("w12");
+					}
+					arrput(fixedInstructions, ((ARM64Instruction){ .type = ARM64_CMP, .src = lhs, .src1 = rhs }));
+					break;
+				}
+				case ARM64_CSET_EQ:
+				case ARM64_CSET_NE:
+				case ARM64_CSET_LT:
+				case ARM64_CSET_LE:
+				case ARM64_CSET_GT:
+				case ARM64_CSET_GE:
+					if (instr->dst.type == OPERAND_STACK_SLOT) {
+						arrput(fixedInstructions, ((ARM64Instruction){ .type = instr->type, .dst = REG("w10") }));
+						arrput(fixedInstructions, ((ARM64Instruction){ .type = ARM64_STR, .src = REG("w10"), .dst = instr->dst }));
+					} else {
+						arrput(fixedInstructions, *instr);
+					}
+					break;
 				case ARM64_MOV:
 				case ARM64_STR:
 				case ARM64_LDR:
@@ -580,6 +662,35 @@ void printARM64Function(const Function* function)
 					getARM64Operand(&instr->src1, src1Buffer, sizeof(src1Buffer));
 					getARM64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
 					printf("  %s %s, %s, %s\n", instructionName, dstBuffer, srcBuffer, src1Buffer);
+					break;
+				case ARM64_CMP:
+					getARM64Operand(&instr->src, srcBuffer, sizeof(srcBuffer));
+					getARM64Operand(&instr->src1, src1Buffer, sizeof(src1Buffer));
+					printf("  cmp %s, %s\n", srcBuffer, src1Buffer);
+					break;
+				case ARM64_CSET_EQ:
+					getARM64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+					printf("  cset %s, eq\n", dstBuffer);
+					break;
+				case ARM64_CSET_NE:
+					getARM64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+					printf("  cset %s, ne\n", dstBuffer);
+					break;
+				case ARM64_CSET_LT:
+					getARM64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+					printf("  cset %s, lt\n", dstBuffer);
+					break;
+				case ARM64_CSET_LE:
+					getARM64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+					printf("  cset %s, le\n", dstBuffer);
+					break;
+				case ARM64_CSET_GT:
+					getARM64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+					printf("  cset %s, gt\n", dstBuffer);
+					break;
+				case ARM64_CSET_GE:
+					getARM64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+					printf("  cset %s, ge\n", dstBuffer);
 					break;
 				case ARM64_LDR:
 					printf("  ldr %s, %s\n", getARM64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer)), getARM64Operand(&instr->src, srcBuffer, sizeof(srcBuffer)));

--- a/VectorC/ast_arm64.h
+++ b/VectorC/ast_arm64.h
@@ -44,6 +44,15 @@ typedef enum {
 	ARM64_LDR,
 	ARM64_STR,
 
+	// Comparisons
+	ARM64_CMP,
+	ARM64_CSET_EQ,
+	ARM64_CSET_NE,
+	ARM64_CSET_LT,
+	ARM64_CSET_LE,
+	ARM64_CSET_GT,
+	ARM64_CSET_GE,
+
 	// Control flow
 	ARM64_RET
 } ARM64InstructionType;

--- a/VectorC/ast_x64.c
+++ b/VectorC/ast_x64.c
@@ -98,6 +98,9 @@ void generateX64Function(FILE* outputFile, const Function* func)
 			case X64_CDQ:
 				fprintf(outputFile, "    cdq\n");
 				break;
+			case X64_CMP:
+				fprintf(outputFile, "    cmpl %s, %s\n", srcBuffer, dstBuffer);
+				break;
 			case X64_IDIV:
 				fprintf(outputFile, "    idivl %s\n", srcBuffer);
 				break;
@@ -116,6 +119,27 @@ void generateX64Function(FILE* outputFile, const Function* func)
 				break;
 			case X64_OR:
 				fprintf(outputFile, "    orl %s, %s\n", srcBuffer, dstBuffer);
+				break;
+			case X64_SETE:
+				fprintf(outputFile, "    sete %s\n", dstBuffer);
+				break;
+			case X64_SETNE:
+				fprintf(outputFile, "    setne %s\n", dstBuffer);
+				break;
+			case X64_SETL:
+				fprintf(outputFile, "    setl %s\n", dstBuffer);
+				break;
+			case X64_SETLE:
+				fprintf(outputFile, "    setle %s\n", dstBuffer);
+				break;
+			case X64_SETG:
+				fprintf(outputFile, "    setg %s\n", dstBuffer);
+				break;
+			case X64_SETGE:
+				fprintf(outputFile, "    setge %s\n", dstBuffer);
+				break;
+			case X64_MOVZX:
+				fprintf(outputFile, "    movzbl %s, %s\n", srcBuffer, dstBuffer);
 				break;
 			case X64_RET:
 				// X86-64 epilogue
@@ -240,6 +264,41 @@ void translateTackyToX64(const TackyProgram* tackyProgram, Program* asmProgram) 
 							.dst  = VAR(instr->binary.dst.varName),
 						});
 						break; // done with DIV/MOD
+					}
+
+					if (op == TACKY_EQ || op == TACKY_NE || op == TACKY_LT || op == TACKY_LE || op == TACKY_GT || op == TACKY_GE) {
+						Operand lhs = (instr->binary.lhs.type == TACKY_VAL_CONSTANT)
+							? IMM(instr->binary.lhs.constantValue)
+							: VAR(instr->binary.lhs.varName);
+						Operand rhs = (instr->binary.rhs.type == TACKY_VAL_CONSTANT)
+							? IMM(instr->binary.rhs.constantValue)
+							: VAR(instr->binary.rhs.varName);
+
+						emitX64(&x64Instructions, (X64Instruction){
+							.type = X64_CMP,
+							.src = rhs,
+							.dst = lhs
+						});
+
+						emitX64(&x64Instructions, (X64Instruction){
+							.type = X64_MOV,
+							.src = IMM(0),
+							.dst = VAR(instr->binary.dst.varName),
+						});
+
+						X64InstructionType setcc =
+							(op == TACKY_EQ) ? X64_SETE :
+							(op == TACKY_NE) ? X64_SETNE :
+							(op == TACKY_LT) ? X64_SETL :
+							(op == TACKY_LE) ? X64_SETLE :
+							(op == TACKY_GT) ? X64_SETG :
+							/* TACKY_GE */    X64_SETGE;
+
+						emitX64(&x64Instructions, (X64Instruction){
+							.type = setcc,
+							.dst = VAR(instr->binary.dst.varName),
+						});
+						break;
 					}
 
 					// --- Generic path: dst = lhs; then apply op with rhs (covers & | ^ << >> and + - *) ---
@@ -433,6 +492,33 @@ void fixupIllegalInstructionsX64(Program* asmProgram, Program* finalAsmProgram) 
 						arrput(fixedInstructions, *instr);  // fallback
 					}
 					break;
+				case X64_CMP:
+					if (instr->dst.type == OPERAND_IMM) {
+						arrput(fixedInstructions, ((X64Instruction){
+							.type = X64_MOV,
+							.src = instr->dst,
+							.dst = scratch
+						}));
+						arrput(fixedInstructions, ((X64Instruction){
+							.type = X64_CMP,
+							.src = instr->src,
+							.dst = scratch
+						}));
+					} else if (srcIsMem && dstIsMem) {
+						arrput(fixedInstructions, ((X64Instruction){
+							.type = X64_MOV,
+							.src = instr->src,
+							.dst = scratch
+						}));
+						arrput(fixedInstructions, ((X64Instruction){
+							.type = X64_CMP,
+							.src = scratch,
+							.dst = instr->dst
+						}));
+					} else {
+						arrput(fixedInstructions, *instr);
+					}
+					break;
 				case X64_IDIV:
 					if (instr->src.type == OPERAND_IMM) {
 						arrput(fixedInstructions, ((X64Instruction){
@@ -485,6 +571,11 @@ void printX64Function(const Function* function) {
 			case X64_CDQ:
 				printf("  cdq\n");
 				break;
+			case X64_CMP:
+				getX64Operand(&instr->src, srcBuffer, sizeof(srcBuffer));
+				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+				printf("  cmpl %s, %s\n", srcBuffer, dstBuffer);
+				break;
 			case X64_IDIV:
 				getX64Operand(&instr->src, srcBuffer, sizeof(srcBuffer));
 				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
@@ -512,6 +603,35 @@ void printX64Function(const Function* function) {
 				getX64Operand(&instr->src, srcBuffer, sizeof(srcBuffer));
 				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
 				printf("  orl %s, %s\n", srcBuffer, dstBuffer);
+				break;
+			case X64_SETE:
+				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+				printf("  sete %s\n", dstBuffer);
+				break;
+			case X64_SETNE:
+				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+				printf("  setne %s\n", dstBuffer);
+				break;
+			case X64_SETL:
+				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+				printf("  setl %s\n", dstBuffer);
+				break;
+			case X64_SETLE:
+				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+				printf("  setle %s\n", dstBuffer);
+				break;
+			case X64_SETG:
+				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+				printf("  setg %s\n", dstBuffer);
+				break;
+			case X64_SETGE:
+				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+				printf("  setge %s\n", dstBuffer);
+				break;
+			case X64_MOVZX:
+				getX64Operand(&instr->src, srcBuffer, sizeof(srcBuffer));
+				getX64Operand(&instr->dst, dstBuffer, sizeof(dstBuffer));
+				printf("  movzbl %s, %s\n", srcBuffer, dstBuffer);
 				break;
 			case X64_RET:
 				printf("  ret\n");

--- a/VectorC/ast_x64.h
+++ b/VectorC/ast_x64.h
@@ -26,6 +26,14 @@ typedef enum {
 	X64_RET,
 	X64_SUB,
 	X64_XOR,
+	X64_CMP,
+	X64_SETE,
+	X64_SETNE,
+	X64_SETL,
+	X64_SETLE,
+	X64_SETG,
+	X64_SETGE,
+	X64_MOVZX,
 	// Shifts
 	X64_SHL_IMM, // shl $imm, r/m32
 	X64_SHL_CL,  // shl %cl, r/m32

--- a/VectorC/tacky.c
+++ b/VectorC/tacky.c
@@ -92,6 +92,24 @@ static TackyValue translateExpression(const ExpressionNode* expr, TackyFunction*
 			case BINOP_SHIFT_RIGHT:
 				op = TACKY_SHIFT_RIGHT;
 				break;
+			case BINOP_EQ:
+				op = TACKY_EQ;
+				break;
+			case BINOP_NE:
+				op = TACKY_NE;
+				break;
+			case BINOP_LT:
+				op = TACKY_LT;
+				break;
+			case BINOP_LE:
+				op = TACKY_LE;
+				break;
+			case BINOP_GT:
+				op = TACKY_GT;
+				break;
+			case BINOP_GE:
+				op = TACKY_GE;
+				break;
 			default:
 				fprintf(stderr, "Unknown binary operator in TACKY generation\n");
 				exit(EXIT_FAILURE);
@@ -218,6 +236,24 @@ void printTackyProgram(const TackyProgram* program) {
 							break;
 						case TACKY_SHIFT_RIGHT:
 							opString = "Shr";
+							break;
+						case TACKY_EQ:
+							opString = "Eq";
+							break;
+						case TACKY_NE:
+							opString = "Ne";
+							break;
+						case TACKY_LT:
+							opString = "Lt";
+							break;
+						case TACKY_LE:
+							opString = "Le";
+							break;
+						case TACKY_GT:
+							opString = "Gt";
+							break;
+						case TACKY_GE:
+							opString = "Ge";
 							break;
 					}
 					printf("        Binary(%s, ", opString);

--- a/VectorC/tacky.h
+++ b/VectorC/tacky.h
@@ -32,6 +32,12 @@ typedef enum {
 	TACKY_BITWISE_XOR,		// bitwise ^
 	TACKY_SHIFT_LEFT,		// <<
 	TACKY_SHIFT_RIGHT,		// >>
+	TACKY_EQ,
+	TACKY_NE,
+	TACKY_LT,
+	TACKY_LE,
+	TACKY_GT,
+	TACKY_GE,
 } TackyBinaryOperator;
 
 typedef enum {


### PR DESCRIPTION
### Motivation
- Support relational and equality binary operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) end-to-end so expressions lower to the TACKY IR and can be emitted by the backends.
- Produce boolean-like `0/1` integer results for comparisons in both x64 and ARM64 backends using target compare+set instructions.

### Description
- Extended the TACKY IR to include relational operators and updated AST→TACKY lowering to emit `TACKY_EQ`, `TACKY_NE`, `TACKY_LT`, `TACKY_LE`, `TACKY_GT`, and `TACKY_GE` (changes in `VectorC/tacky.h` and `VectorC/tacky.c`).
- Lowered relational Tacky ops into target compare sequences:
  - x64: emit `cmpl` followed by `movl $0, dst` and a `setcc` (mapped to `sete/setne/setl/...`) to produce a `0/1` result; added new x64 instruction kinds and printer support (changes in `VectorC/ast_x64.h` and `VectorC/ast_x64.c`).
  - ARM64: emit `cmp` followed by `cset <cond>` to produce a `0/1` result; added new ARM64 instruction kinds and printer support (changes in `VectorC/ast_arm64.h` and `VectorC/ast_arm64.c`).
- Updated legalization/fixup passes to handle new compare/cset instructions and operand constraints (materialize immediates, avoid mem->mem compares, and store condition-result registers into stack slots when needed) for both architectures.
- Updated assembly printers / debug printers to render `cmp`, `set*`, `cset` and the new instructions for easier inspection.

### Testing
- Built the toolchain with `clang -std=gnu17 VectorC/*.c -o /tmp/vecc_test` and the build succeeded.
- Exercised the new lowering and codegen end-to-end using a small test file (`/tmp/rel_ops.c`) by running ` /tmp/vecc_test /tmp/rel_ops.c` and also ` /tmp/vecc_test /tmp/rel_ops.c --codegen`; the generated program produced the expected exit code (`3`) and the printed assembly shows the new compare/set sequences on x64.
- Verified ARM64 translation path using ` /tmp/vecc_test /tmp/rel_ops.c --codegen -arch=arm64` to ensure ARM64 `cmp`/`cset` sequences and legalization code are exercised (ran successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c51905708832a80af3d5c1975021e)